### PR TITLE
수정: sendDataReport 시간 범위 정밀도 개선

### DIFF
--- a/report/src/main/kotlin/com/zeki/report/DataReportService.kt
+++ b/report/src/main/kotlin/com/zeki/report/DataReportService.kt
@@ -35,10 +35,11 @@ class DataReportService(
 
     @Transactional
     fun sendDataReport(now: LocalDateTime) {
-        val startDateTime = now.withSecond(0)
-        val endDateTime = now.withSecond(59)
+        val startDateTime = now.withSecond(0).withNano(0)
+        val endDateTime = now.withSecond(59).withNano(999999999)
         val dataReports =
             dataReportRepository.findByReportDateTimeBetween(startDateTime, endDateTime)
+        
         dataReports.forEach {
             val reqBody = objectMapper.readValue(it.content, DiscordWebhookDto::class.java)
             ExceptionUtils.log.info("sendDataReport reqBody: $reqBody")


### PR DESCRIPTION
- 시작 및 종료 시간에 nano 초 단위 정밀도를 추가하였습니다.
- 데이터 조회 시 정확한 시간 범위를 보장하기 위함입니다.