### PR TITLE
sleep 시간 변경

### DIFF
--- a/kis-server/src/main/kotlin/com/zeki/kisserver/domain/kis/stock_price/CrawlNaverFinanceService.kt
+++ b/kis-server/src/main/kotlin/com/zeki/kisserver/domain/kis/stock_price/CrawlNaverFinanceService.kt
@@ -34,7 +34,7 @@ class CrawlNaverFinanceService(
         reqParam.add("startTime", startDate)
         reqParam.add("timeframe", timeframe)
 
-        sleep(1100L)
+        sleep(110L)
         val responseDatas = okHttpClientConnector.connect<Unit, String>(
             OkHttpClientConnector.ClientType.NAVER_FINANCE,
             HttpMethod.GET,


### PR DESCRIPTION
- 네이버 금융 요청 전 대기 시간을 1100ms에서 110ms로 단축
- 성능 최적화를 위해 sleep 시간을 수정