### PR TITLE
ReportScheduler 분리 및 Scheduler 작업 시간 변경

### DIFF
--- a/kis-server/src/main/kotlin/com/zeki/kisserver/domain/schduler/ReportScheduler.kt
+++ b/kis-server/src/main/kotlin/com/zeki/kisserver/domain/schduler/ReportScheduler.kt
@@ -1,0 +1,22 @@
+package com.zeki.kisserver.domain.schduler
+
+import com.zeki.report.DataReportService
+import org.springframework.scheduling.annotation.Scheduled
+import org.springframework.stereotype.Component
+import java.time.LocalDateTime
+
+/**
+ * DEBUG 로그 표시하지 않도록 분리
+ */
+@Component
+class ReportScheduler(
+    private val dataReportService: DataReportService,
+) {
+
+    @Scheduled(cron = "0 * * * * *")
+    fun sendReportWebhook() {
+        val now = LocalDateTime.now()
+        dataReportService.sendDataReport(now)
+    }
+
+}

--- a/kis-server/src/main/kotlin/com/zeki/kisserver/domain/schduler/Scheduler.kt
+++ b/kis-server/src/main/kotlin/com/zeki/kisserver/domain/schduler/Scheduler.kt
@@ -73,13 +73,7 @@ class Scheduler(
         )
     }
 
-    @Scheduled(cron = "0 * * * * *")
-    fun sendReportWebhook() {
-        val now = LocalDateTime.now()
-        dataReportService.sendDataReport(now)
-    }
-
-    @Scheduled(cron = "0 0 19 * * *")
+    @Scheduled(cron = "0 1 18 * * *")
     fun updateStockInfo() {
         val stockCodeList = getStockCodeService.getStockCodeStringList()
         val upsertInfo = stockInfoService.upsertStockInfo(stockCodeList)
@@ -113,13 +107,13 @@ class Scheduler(
             startDateTime =
                 LocalDateTime.of(
                     /* date = */ LocalDate.now(),
-                    /* time = */ LocalTime.of(21, 0)
+                    /* time = */ LocalTime.of(20, 0)
                 ),
             content = content
         )
     }
 
-    @Scheduled(cron = "0 0 20 * * *")
+    @Scheduled(cron = "0 1 19 * * *")
     fun updateStockPrice() {
         val stockCodeList = getStockCodeService.getStockCodeStringList()
         val upsertPrice = stockPriceService.upsertStockPrice(stockCodeList, LocalDate.now(), 10)
@@ -153,7 +147,7 @@ class Scheduler(
             startDateTime =
                 LocalDateTime.of(
                     /* date = */ LocalDate.now(),
-                    /* time = */ LocalTime.of(21, 0)
+                    /* time = */ LocalTime.of(20, 0)
                 ),
             content = content
         )

--- a/mole-tunnel-db/src/main/kotlin/com/zeki/mole_tunnel_db/repository/DataReportRepository.kt
+++ b/mole-tunnel-db/src/main/kotlin/com/zeki/mole_tunnel_db/repository/DataReportRepository.kt
@@ -1,14 +1,12 @@
 package com.zeki.mole_tunnel_db.repository
 
-import com.zeki.common.em.ReportType
 import com.zeki.mole_tunnel_db.entity.DataReport
 import org.springframework.data.jpa.repository.JpaRepository
 import java.time.LocalDateTime
 
 interface DataReportRepository : JpaRepository<DataReport, Long> {
-    fun findByReportDateTimeBetweenAndName(
+    fun findByReportDateTimeBetween(
         startDateTime: LocalDateTime,
-        endDateTime: LocalDateTime,
-        name: ReportType
+        endDateTime: LocalDateTime
     ): MutableList<DataReport>
 }

--- a/report/src/main/kotlin/com/zeki/report/DataReportService.kt
+++ b/report/src/main/kotlin/com/zeki/report/DataReportService.kt
@@ -39,23 +39,22 @@ class DataReportService(
         val startDateTime = now.withSecond(0).withNano(0)
         val endDateTime = now.withSecond(59)
         val dataReports =
-            dataReportRepository.findByReportDateTimeBetweenAndName(
+            dataReportRepository.findByReportDateTimeBetween(
                 startDateTime,
-                endDateTime,
-                ReportType.DATA_GO
+                endDateTime
             )
 
         dataReports.forEach {
             ExceptionUtils.log.info { "sendDataReport: $it" }
             val reqBody = objectMapper.readValue(it.content, DiscordWebhookDto::class.java)
-            val connect = okHttpClientConnector.connect(
+            okHttpClientConnector.connect(
                 clientType = OkHttpClientConnector.ClientType.DEFAULT,
                 method = HttpMethod.POST,
                 path = it.url,
                 requestBody = reqBody,
                 responseClassType = JsonNode::class.java,
             )
-            //TODO: response 확인 후 isSend 값 변경
+
             it.isSend = "Y"
         }
 


### PR DESCRIPTION
- ReportScheduler 클래스를 생성하여 sendReportWebhook 작업을 분리
- 기존 Scheduler 클래스에서 관련 로직 제거
- updateStockInfo, updateStockPrice 등의 작업 시간을 조정
- findByReportDateTimeBetweenAndName 메소드를 findByReportDateTimeBetween으로 변경